### PR TITLE
feat: add toggle for displaying Plan vs Actual baselines in Gantt chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,13 @@ function GanttView({
   // Planning history: track baselines and log changes
   const { baselines, syncBaselines, logChange, logStatusTransition } = usePlanningHistory(selectedProjectId);
 
+  // Plan vs Actual overlay (dashed baseline ghost bars) — user preference, persisted
+  const [showBaselines, setShowBaselines] = useState(() => localStorage.getItem('gantt_show_baselines') !== '0');
+  const handleShowBaselinesChange = useCallback((show: boolean) => {
+    setShowBaselines(show);
+    localStorage.setItem('gantt_show_baselines', show ? '1' : '0');
+  }, []);
+
   // Sync baselines whenever tasks load
   useEffect(() => {
     if (tasks.length > 0) syncBaselines(tasks);
@@ -163,6 +170,8 @@ function GanttView({
         filteredCount={filteredTasks.length}
         groupBy={groupBy}
         onGroupByChange={setGroupBy}
+        showBaselines={showBaselines}
+        onShowBaselinesChange={handleShowBaselinesChange}
       />
 
       <StatsRow tasks={filteredTasks} />
@@ -182,7 +191,7 @@ function GanttView({
           onCycleStatus={cycleStatusWithHistory}
           onCreateRelation={createRelation}
           onReorder={reorderTask}
-          baselines={baselines}
+          baselines={showBaselines ? baselines : undefined}
           dateFrom={filters.dateFrom}
           dateTo={filters.dateTo}
         />

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -18,6 +18,8 @@ interface Props {
   groupBy: GroupBy;
   onGroupByChange: (g: GroupBy) => void;
   hideProjectSelector?: boolean;
+  showBaselines?: boolean;
+  onShowBaselinesChange?: (show: boolean) => void;
 }
 
 const PRIORITY_CHIPS = [
@@ -87,6 +89,14 @@ function GroupIcon() {
   );
 }
 
+function BaselineIcon() {
+  return (
+    <svg width="14" height="10" viewBox="0 0 20 12" fill="none" className="shrink-0">
+      <rect x="1" y="1" width="18" height="10" rx="3" stroke="currentColor" strokeWidth="1.6" strokeDasharray="3 2.4" />
+    </svg>
+  );
+}
+
 function XIcon() {
   return (
     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
@@ -109,6 +119,8 @@ export default function FilterBar({
   groupBy,
   onGroupByChange,
   hideProjectSelector,
+  showBaselines,
+  onShowBaselinesChange,
 }: Props) {
   const togglePriority = (val: number) => {
     const next = new Set(filters.priorities);
@@ -250,6 +262,30 @@ export default function FilterBar({
           to={filters.dateTo}
           onChange={(dateFrom, dateTo) => onFiltersChange({ ...filters, dateFrom, dateTo })}
         />
+
+        {/* Plan vs Actual — toggles the dashed baseline ghost bars */}
+        {onShowBaselinesChange && (
+          <>
+            <div className="w-px h-5 bg-border-primary shrink-0" />
+            <button
+              onClick={() => onShowBaselinesChange(!showBaselines)}
+              aria-pressed={showBaselines}
+              title={
+                showBaselines
+                  ? 'Hide original plan overlay (dashed bars)'
+                  : 'Show original plan overlay (dashed bars)'
+              }
+              className={`h-7 px-2.5 rounded-full text-[11px] font-medium cursor-pointer transition-all border select-none active:scale-95 inline-flex items-center gap-1.5 shrink-0 ${
+                showBaselines
+                  ? 'border-amber-400/60 text-amber-500 bg-amber-400/10'
+                  : 'bg-bg-card border-border-primary text-text-muted hover:border-border-secondary hover:text-text-secondary'
+              }`}
+            >
+              <BaselineIcon />
+              Plan vs Actual
+            </button>
+          </>
+        )}
 
         <div className="flex-1" />
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Related Issue

<!-- e.g. Closes #12 -->

## Changes

-

## Screenshots

<!-- If applicable -->

## Checklist

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] Tested locally
